### PR TITLE
Remove gulp from npm global packages example

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,7 +94,7 @@ symfony_root_folder   = "/vagrant/symfony" # Where to install Symfony.
 nodejs_version        = "latest"   # By default "latest" will equal the latest stable version
 nodejs_packages       = [          # List any global NodeJS packages that you want to install
   #"grunt-cli",
-  #"gulp",
+  #"tsd",
   #"bower",
   #"yo",
 ]


### PR DESCRIPTION
Remove gulp from global node packages example since it seems like bad practice to use globally. Add TypeScript Definition manager instead as better example.
