### PR TITLE
Add npm-check-updates as default global package

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,6 +93,7 @@ symfony_root_folder   = "/vagrant/symfony" # Where to install Symfony.
 
 nodejs_version        = "latest"   # By default "latest" will equal the latest stable version
 nodejs_packages       = [          # List any global NodeJS packages that you want to install
+  "npm-check-updates"              # Show npm dependencies updates with ncu command
   #"grunt-cli",
   #"tsd",
   #"bower",


### PR DESCRIPTION
This adds the ncu command for checking npm package updates as default global dependency when node is installed. Mostly needed when migrating projects to vagrant or on maintenance of older projects.
